### PR TITLE
chore: finalize Render migration (v0.9.0, bump2version fix, handoff close)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.9.0
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ current_version = 0.9.0
 commit = True
 tag = True
 tag_name = v{new_version}
-commit_message = chore: bump version {current_version} → {new_version}
+message = chore: bump version {current_version} → {new_version}
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,9 @@
 [bumpversion]
-current_version = 0.7.2
+current_version = 0.8.0
 commit = True
 tag = True
 tag_name = v{new_version}
+commit_message = chore: bump version {current_version} → {new_version}
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"

--- a/.cursor/progress/3-DONE-render-migration-handoff.md
+++ b/.cursor/progress/3-DONE-render-migration-handoff.md
@@ -6,7 +6,7 @@ github_issue: 32
 **Date:** 2026-04-27 (in progress)
 **Related:** `.cursor/refactors/2-use-a-more-professional-deployment-solution.md`
 **Modeled on:** receipt-ranger migration (`~/Desktop/receipt-ranger/.cursor/progress/10-DONE-render-migration-handoff.md`)
-**Status:** Phases 1–3 complete; Phase 4 (functional verification) pending — to be done 2026-04-28
+**Status:** Phases 1–4 and 6 complete (2026-04-29). Phase 5 skipped (no DNS cutover). Phase 7 deferred.
 **Render URL:** https://recipes-ai-app.onrender.com/
 **Resume from Claude session:** `90bc7f0e-900d-4fd5-8488-070514861562` (in `~/.claude/projects/-Users-grahamnessler-Desktop-pinecone-recipes-ai-app/`)
 
@@ -110,7 +110,7 @@ This is the test that would have failed if the `PINECONE_NAMESPACE` fix had been
   - Update `README.md` Deployment section: replace "Streamlit Community Cloud" instructions with Render setup
   - Remove app from SCC dashboard (https://share.streamlit.io)
   - Open PR `redeploy → master`, merge
-  - **Update Render's tracked branch** from `redeploy` to `master` in Settings → Build & Deploy (Render does NOT auto-switch — receipt-ranger lesson)
+  - ~~**Update Render's tracked branch** from `redeploy` to `master` in Settings → Build & Deploy (Render does NOT auto-switch — receipt-ranger lesson)~~ — **Outdated as of 2026-04-29:** Render now auto-switches the tracked branch to the repo's default branch when the configured branch is deleted. Verified in Render Events: "Branch changed to master / Previous branch redeploy was deleted from source repository." Manual switch is no longer required.
   - `bump2version minor` per house rules (this is a significant refactor)
 - **Phase 7 — optional polish:** custom favicon (skipped in receipt-ranger; same call here unless desired)
 
@@ -161,3 +161,7 @@ This is a separate logical change from the Render migration, but it would have c
 - **`baml-py` should be excluded** from production install when BAML is offline-only. It pins exact versions and would fight any future BAML upgrade.
 - **301 redirects cache aggressively** — if/when DNS cutover happens later, expect to clear browser cache or use incognito to test.
 - **CFS pre-commit `content_conflict` warnings are non-blocking** — same behavior as in receipt-ranger.
+- **Render auto-switches tracked branch when source branch is deleted** (verified 2026-04-29). The receipt-ranger lesson saying otherwise is now outdated. Deleting the source branch on origin will cause Render to fall back to the repo's GitHub default branch automatically and surface a "Branch changed to X" event.
+- **`bump2version` 1.x reads `.bumpversion.cfg`, not `pyproject.toml`** — the `[tool.bump2version]` block in `pyproject.toml` is not read by the tool and silently drifts from the real config. Keep the source of truth in `.bumpversion.cfg`. Also: the commit-message config key is `message =`, not `commit_message =` (the latter is silently ignored).
+
+<!-- DONE -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,3 +146,16 @@ Tests should cover:
 - Pinecone upsert/query operations
 - Recipe matching logic
 - Fallback behavior when no matches found
+
+## Versioning
+
+Version bumps MUST go through `bump2version` — never edit `pyproject.toml`'s `version` field by hand.
+
+```bash
+bump2version minor   # significant feature or refactor
+bump2version patch   # bug fix
+```
+
+`bump2version` updates `pyproject.toml` and `.bumpversion.cfg` in lockstep, creates a `chore: bump version X → Y` commit, and tags `vX.Y.Z`. Manual edits cause silent drift between the two config files (this happened across 0.7.0–0.8.0 and forced agents to abandon the tool).
+
+If `bump2version` errors, fix the config rather than working around it manually. Common failure mode: `.bumpversion.cfg` `current_version` doesn't match the actual `version` string in `pyproject.toml`. Re-sync the cfg, then re-run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,6 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.bump2version]
-current_version = "0.8.0"
-commit = true
-tag = true
-files = ["pyproject.toml"]
-
 [project]
 name = "recipes-ai-app"
 version = "0.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "recipes-ai-app"
-version = "0.8.0"
+version = "0.9.0"
 description = "Recipe chatbot using RAG with Pinecone vector database"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Fix `.bumpversion.cfg` drift (was at 0.7.2, synced to 0.8.0) and drop the orphan `[tool.bump2version]` block from `pyproject.toml`
- Bump to **v0.9.0** for the Render migration (significant refactor)
- Add a `Versioning` section to AGENTS.md requiring `bump2version` for all bumps
- Close the Render migration handoff doc with two correction notes (Render auto-switches tracked branch on source deletion; bump2version's commit-message key is `message=`)

## Test plan

- [x] `bump2version --dry-run --list patch` reports `new_version=0.9.1`, `message=chore: bump version ...`
- [x] `pyproject.toml` shows `version = "0.9.0"`
- [x] `v0.9.0` tag exists locally and was pushed with `--follow-tags`
- [ ] CI passes on PR
- [ ] After merge, verify Render auto-deploys from master and the live site is responsive